### PR TITLE
CI: Bump actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -33,7 +33,7 @@ jobs:
         go get -u golang.org/x/lint/golint
         go get -u golang.org/x/tools/cmd/goimports
         go get -u github.com/segmentio/golines
-    
+
     - name: Check formatting
       run: |
         if [[ $(golines . -l) ]]; then
@@ -53,7 +53,7 @@ jobs:
       run: go test ./... -v
 
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.3.0
       with:
         minikube version: 'v1.15.1'
         kubernetes version: 'v1.19.0'


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).